### PR TITLE
Don't silently fail if Fuse can't be started.

### DIFF
--- a/fuse.py
+++ b/fuse.py
@@ -208,9 +208,13 @@ class Fuse():
 						log().info("Calling subprocess '%s'", str(start_daemon))
 						if os.name == "nt":
 							CREATE_NO_WINDOW = 0x08000000			
-							subprocess.call(start_daemon, creationflags=CREATE_NO_WINDOW)
+							subprocess.check_output(start_daemon, creationflags=CREATE_NO_WINDOW, stderr=subprocess.STDOUT)
 						else:
-							subprocess.call(start_daemon)
+							subprocess.check_output(start_daemon, stderr=subprocess.STDOUT)
+					except subprocess.CalledProcessError as e:
+						log().error("Fuse returned exit status " + str(e.returncode) + ". Output was '" + e.output.decode("utf-8") + "'.")
+						error_message("Error starting Fuse:\n\n" + e.output.decode("utf-8"))
+						return
 					except:
 						log().error("Fuse not found: " + traceback.format_exc())
 						gFuse.showFuseNotFound()


### PR DESCRIPTION
subprocess.call() returns an error code that we didn't check. Instead
use subprocess.check_output() that throws an exception if the subprocess
returns non-zero. In that case, log the output from Fuse and alert the
user that there is a problem.

An argument was made that the user doesn't need to be alerted about this
problem, since staring Fuse is not a result of a deliberate user action.
In my opinion it is important for the user to be aware that there is an
error, so he or she can try to fix it. The alternative is that things
like code completion just don't work.
