### PR TITLE
Make FocusEditor work when multiple Sublime windows are open

### DIFF
--- a/focus_editor.py
+++ b/focus_editor.py
@@ -24,17 +24,17 @@ class FocusEditorService:
 
 	def tryHandle(self, request):
 		if request.name != "FocusEditor":
-			return false
-		if self._projectIsOpen(request.arguments["Project"]):
-			fileName = request.arguments["File"]
-			line = request.arguments["Line"]
-			column = request.arguments["Column"]
-			if not os.path.isfile(fileName):
-				self.returnFailure("File '{}' does not exist".format(fileName), request.id)
-				return True
+			return False
+		fileName = request.arguments["File"]
+		line = request.arguments["Line"]
+		column = request.arguments["Column"]
+		if not os.path.isfile(fileName):
+			self._returnFailure("File '{}' does not exist".format(fileName), request.id)
+			return True
+		window = self._tryGetWindowFor(request.arguments["Project"])
+		if window:
 			try:
-				window = sublime.active_window()
-				view = window.open_file( "{}:{}:{}".format(fileName, line, column), sublime.ENCODED_POSITION)
+				window.open_file( "{}:{}:{}".format(fileName, line, column), sublime.ENCODED_POSITION)
 				if sublime.platform() == "osx":
 					self._focusWindowOSX()
 					self.msgManager.sendResponse(self.interop, request.id, "Success")
@@ -43,21 +43,22 @@ class FocusEditorService:
 					self.msgManager.sendResponse(self.interop, request.id, "Success", {"FocusHwnd":window.hwnd()})
 					return True
 			except Exception as e:
-				self.returnFailure(str(e), request.id)
+				self._returnFailure(str(e), request.id)
 				return True
 		return False
 
-	def returnFailure(self, msg, id):
+	def _returnFailure(self, msg, id):
 		log().info("FocusEditorService: " + msg)
 		self.msgManager.sendResponse(self.interop, id, "Error", {}, [{"Code":2, "Message": msg}])
 
-	def _projectIsOpen(self, project):
+	def _tryGetWindowFor(self, project):
 		if not os.path.isfile(project):
-			return False
-		for folder in sublime.active_window().folders():
-			if project.startswith(folder):
-				return True
-		return False
+			return None
+		for window in sublime.windows():
+			for folder in window.folders():
+				if project.startswith(folder):
+					return window
+		return None
 
 	def _focusWindowOSX(self):
 		cmd = """


### PR DESCRIPTION
Previously, a `FocusEditor` request would fail if a window for that
project was open, but was not the active window.

On Windows, the correct window will also be raised to the foreground. On
OS X however, the Sublime app itself (with all its windows) will be
raised, leaving the previously topmost window at the top. There is no way to
raise a specific Sublime window to the front on OS X, see for instance
the discussion on
https://forum.sublimetext.com/t/how-to-focus-window/5219.